### PR TITLE
Fix README project name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 ## 📁 專案結構
 
 ```
-ChatBot/
+Chatbot/
 ├── legal_consult_agent/          # 核心代理模組
 │   ├── __init__.py
 │   ├── agent.py                  # LangGraph 工作流程定義
@@ -129,7 +129,7 @@ ChatBot/
 1. **Clone 專案**
 ```bash
 git clone https://github.com/zrkluke/Chatbot.git
-cd ChatBot
+cd Chatbot
 ```
 
 2. **建置環境**


### PR DESCRIPTION
## Summary
- update the project structure snippet to refer to the Chatbot directory
- correct the quick start instructions to use the proper Chatbot casing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db31b16ff4832eb89019f90a592b3e